### PR TITLE
Handle reset_at in rate limit errors

### DIFF
--- a/src/common/grok-errors.ts
+++ b/src/common/grok-errors.ts
@@ -78,9 +78,13 @@ export function createGrokError(status: number, data: any): GrokError {
     case 404:
       return new GrokResourceNotFoundError(message);
     case 429:
-      const resetAt = new Date();
-      // Add 1 hour as a default if reset time is not provided
-      resetAt.setHours(resetAt.getHours() + 1);
+      let resetAt: Date;
+      if (data && data.reset_at) {
+        const parsed = new Date(data.reset_at);
+        resetAt = isNaN(parsed.getTime()) ? new Date(Date.now() + 60 * 60 * 1000) : parsed;
+      } else {
+        resetAt = new Date(Date.now() + 60 * 60 * 1000);
+      }
       return new GrokRateLimitError(message, resetAt);
     case 500:
     case 502:


### PR DESCRIPTION
## Summary
- parse `reset_at` from API response when creating `GrokRateLimitError`
- fall back to one hour from now if `reset_at` is missing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68415995f75083239a94c96dce0245b3